### PR TITLE
Added ARM64 support to embedded-consul and added ARM64 job into Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,20 @@
 language: groovy
 
+arch:
+  - amd64
+  - arm64
+
 jdk:
   - oraclejdk8
 
 dist: precise
+
+install:
+  - if [ "${TRAVIS_CPU_ARCH}" == "arm64" ]; then
+     sudo apt-get install openjdk-8-jdk;
+     export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-arm64;
+     export PATH=$JAVA_HOME/bin:$PATH;
+    fi
 
 script:
   - "./gradlew check"

--- a/src/main/groovy/com/pszymczyk/consul/infrastructure/HttpBinaryRepository.groovy
+++ b/src/main/groovy/com/pszymczyk/consul/infrastructure/HttpBinaryRepository.groovy
@@ -15,7 +15,9 @@ class HttpBinaryRepository {
         String os = OsResolver.resolve()
         String cdn = System.getenv(CONSUL_BINARY_CDN) != null ? System.getenv(CONSUL_BINARY_CDN)
                 : System.getProperty(CONSUL_BINARY_CDN) != null ? System.getProperty(CONSUL_BINARY_CDN) : CONSUL_DEFAULT_CDN;
-        String url = "${cdn}${version}/consul_${version}_${os}_amd64.zip"
+        String ARCH = System.getProperty('os.arch')
+        ARCH = ( ARCH.equals("aarch64") == true ? "arm64" : "amd64" )
+        String url = "${cdn}${version}/consul_${version}_${os}_${ARCH}.zip"
         OutputStream outputStream = file.newOutputStream()
         outputStream << new URL(url).openStream()
         outputStream.close()


### PR DESCRIPTION

**Hi**

**Package Owner:** Rahul Aggarwal

**PR change Details:**
**1. Patch Details:** Following 2 files have been modified :

1.  .travis.yml: 'arch: arm64' has been added, and PATH/JAVA_HOME is set to OpenJDK-8-JDK.
2.  HttpBinaryRepository.groovy: code is added to set URL according to architecture.

**2. Testing Detail:**
Please find my Travis-ci testing jobs here: <https://travis-ci.com/github/rahulgit-ps/embedded-consul>

**3. PR Description:** Here is my commit message :

1. Added ARM64 architecture to the .travis.yml and set JAVA_HOME and
PATH for openjdk-8-jdk.
2. Added code in HttpBinaryRepository.groovy file for setting url
according to the build architecture.

Signed-off-by: odidev <odidev@puresoftware.com>

**4. Peer Reviewer:** Pruthvi Teja
**5. Reviewer:** Rajeev Nayan

**Thanks
Rahul Aggarwal**